### PR TITLE
Phil/Fix publication class handling in Leadin block

### DIFF
--- a/src/blocks/leadin/leadin.js
+++ b/src/blocks/leadin/leadin.js
@@ -45,7 +45,7 @@ const {
 } = wp.hooks;
 
 // The current publication owner.
-const publicationClass = document.getElementById( 'bu_publication_owner' ).value;
+const publication = document.getElementById( 'bu_publication_owner' );
 
 // Block attributes.
 const blockAttributes = {
@@ -195,9 +195,9 @@ registerBlockType( 'bu/leadin', {
 
 		const classes = classnames(
 			'wp-block-editorial-leadin',
-			publicationClass + '-block-editorial-leadin',
 			className,
 			{
+				[ `${publication.value}-block-editorial-leadin` ]: publication && publication.value !== '',
 				'has-box': box && ( isStyleEmphasisOnText || isStyleTextOverImage || isStyleSideBySide ),
 				'has-wider': wide && isStyleSideBySide,
 				'has-flip': flip && isStyleSideBySide,


### PR DESCRIPTION
Fixes part of https://github.com/bu-ist/bu-blocks/issues/160.

This was throwing an error and preventing this block and all those after it from loading up if bu-prepress was not activated.