### PR TITLE
Jeremy / Fix JS error when custom HTML block is first auto-saved

### DIFF
--- a/src/blocks/custom-html/custom-html.js
+++ b/src/blocks/custom-html/custom-html.js
@@ -180,10 +180,17 @@ registerBlockType( 'editorial/custom-html', {
 			return;
 		}
 
+		let customTextArea = document.querySelector( '#block-' + customBlockID + ' textarea' );
+
+		// This may be true on the first load of some posts.
+		if ( null === customTextArea ) {
+			return;
+		}
+
 		let post = {
 			post_id: postID,
 			custom_block_id: customBlockID,
-			html: document.querySelector( '#block-' + customBlockID + ' textarea' ).value,
+			html: customTextArea.value,
 		}
 
 		// Save the data for this block using a custom endpoint.


### PR DESCRIPTION
In some cases, an autosave fired by the editor when a BU Custom HTML block is present will result in a JS console error because the `textarea` element is not yet available.

Adding a check for that element allows us to skip the save if the editor is not ready.