### PR TITLE
Jeremy / Use `getAllowedFormats()` to provide both possible attributes

### DIFF
--- a/src/blocks/listicle/listicle.js
+++ b/src/blocks/listicle/listicle.js
@@ -218,7 +218,8 @@ registerBlockType( 'editorial/listicle', {
 								value={ credit }
 								onChange={ value => setAttributes( { credit: value } ) }
 								placeholder={ __( 'Add Photo or Video Credit…' ) }
-								formattingControls={ [ 'bold', 'italic', 'link' ] }
+								formattingControls={ getAllowedFormats( 'formattingControls', [ 'bold', 'italic', 'link' ] ) }
+								allowedFormats={ getAllowedFormats( 'allowedFormats', [ 'core/bold', 'core/italic', 'core/link' ] ) }
 								keepPlaceholderOnFocus
 							/>
 						</figure>

--- a/src/blocks/stat/stat.js
+++ b/src/blocks/stat/stat.js
@@ -13,6 +13,7 @@ import './editor.scss';
 
 // Internal dependencies.
 import themeOptions from '../../global/theme-options';
+import getAllowedFormats from '../../global/allowed-formats';
 
 // WordPress dependencies.
 const {
@@ -166,7 +167,8 @@ registerBlockType( 'bu/stat', {
 								placeholder={ __( 'Opening text…' ) }
 								value={ preText }
 								onChange={ value => setAttributes( { preText: value } ) }
-								formattingControls={ [ 'bold', 'italic' ] }
+								formattingControls={ getAllowedFormats( 'formattingControls', [ 'bold', 'italic' ] ) }
+								allowedFormats={ getAllowedFormats( 'allowedFormats', [ 'core/bold', 'core/italic' ] ) }
 							/>
 						}
 
@@ -185,7 +187,8 @@ registerBlockType( 'bu/stat', {
 								placeholder={ __( 'Closing text…' ) }
 								value={ postText }
 								onChange={ value => setAttributes( { postText: value } ) }
-								formattingControls={ [ 'bold', 'italic' ] }
+								formattingControls={ getAllowedFormats( 'formattingControls', [ 'bold', 'italic' ] ) }
+								allowedFormats={ getAllowedFormats( 'allowedFormats', [ 'core/bold', 'core/italic' ] ) }
 							/>
 						}
 

--- a/src/blocks/stat/stats.js
+++ b/src/blocks/stat/stats.js
@@ -13,6 +13,7 @@ import './editor.scss';
 
 // Internal dependencies.
 import './stat';
+import getAllowedFormats from '../../global/allowed-formats';
 
 // WordPress dependencies.
 const {
@@ -162,7 +163,8 @@ registerBlockType( 'bu/stats', {
 						placeholder={ __( 'Add a caption (optional)…' ) }
 						value={ caption }
 						onChange={ value => setAttributes( { caption: value } ) }
-						formattingControls={ [ 'bold', 'italic', 'link' ] }
+						formattingControls={ getAllowedFormats( 'formattingControls', [ 'bold', 'italic', 'link' ] ) }
+						allowedFormats={ getAllowedFormats( 'allowedFormats', [ 'core/bold', 'core/italic', 'core/link' ] ) }
 						keepPlaceholderOnFocus
 					/>
 				</figure>


### PR DESCRIPTION
Some recent blocks changes added either new blocks or new attributes to existing blocks. This updates those to use both the `formattingControls` and `allowedFormats` attribute.

See #178 for background.