### PR TITLE
Jeremy / Revert "Use `getAllowedFormats()` to provide both possible attributes"

### DIFF
--- a/src/blocks/listicle/listicle.js
+++ b/src/blocks/listicle/listicle.js
@@ -218,8 +218,7 @@ registerBlockType( 'editorial/listicle', {
 								value={ credit }
 								onChange={ value => setAttributes( { credit: value } ) }
 								placeholder={ __( 'Add Photo or Video Credit…' ) }
-								formattingControls={ getAllowedFormats( 'formattingControls', [ 'bold', 'italic', 'link' ] ) }
-								allowedFormats={ getAllowedFormats( 'allowedFormats', [ 'core/bold', 'core/italic', 'core/link' ] ) }
+								formattingControls={ [ 'bold', 'italic', 'link' ] }
 								keepPlaceholderOnFocus
 							/>
 						</figure>

--- a/src/blocks/stat/stat.js
+++ b/src/blocks/stat/stat.js
@@ -13,7 +13,6 @@ import './editor.scss';
 
 // Internal dependencies.
 import themeOptions from '../../global/theme-options';
-import getAllowedFormats from '../../global/allowed-formats';
 
 // WordPress dependencies.
 const {
@@ -173,8 +172,7 @@ registerBlockType( 'bu/stat', {
 								placeholder={ __( 'Opening text…' ) }
 								value={ preText }
 								onChange={ value => setAttributes( { preText: value } ) }
-								formattingControls={ getAllowedFormats( 'formattingControls', [ 'bold', 'italic' ] ) }
-								allowedFormats={ getAllowedFormats( 'allowedFormats', [ 'core/bold', 'core/italic' ] ) }
+								formattingControls={ [ 'bold', 'italic' ] }
 							/>
 						}
 
@@ -193,8 +191,7 @@ registerBlockType( 'bu/stat', {
 								placeholder={ __( 'Closing text…' ) }
 								value={ postText }
 								onChange={ value => setAttributes( { postText: value } ) }
-								formattingControls={ getAllowedFormats( 'formattingControls', [ 'bold', 'italic' ] ) }
-								allowedFormats={ getAllowedFormats( 'allowedFormats', [ 'core/bold', 'core/italic' ] ) }
+								formattingControls={ [ 'bold', 'italic' ] }
 							/>
 						}
 

--- a/src/blocks/stat/stats.js
+++ b/src/blocks/stat/stats.js
@@ -13,7 +13,6 @@ import './editor.scss';
 
 // Internal dependencies.
 import './stat';
-import getAllowedFormats from '../../global/allowed-formats';
 
 // WordPress dependencies.
 const {
@@ -163,8 +162,7 @@ registerBlockType( 'bu/stats', {
 						placeholder={ __( 'Add a caption (optional)…' ) }
 						value={ caption }
 						onChange={ value => setAttributes( { caption: value } ) }
-						formattingControls={ getAllowedFormats( 'formattingControls', [ 'bold', 'italic', 'link' ] ) }
-						allowedFormats={ getAllowedFormats( 'allowedFormats', [ 'core/bold', 'core/italic', 'core/link' ] ) }
+						formattingControls={ [ 'bold', 'italic', 'link' ] }
 						keepPlaceholderOnFocus
 					/>
 				</figure>


### PR DESCRIPTION
This reverts commit 7acc7f59f33ee1596694e856704fec10bf03eb0c.

`getAllowedFormats()` is not yet available in the `develop` branch.