### PR TITLE
Jeremy / Remove template locking on photo essay block

### DIFF
--- a/src/blocks/photoessay/photoessay.js
+++ b/src/blocks/photoessay/photoessay.js
@@ -161,7 +161,6 @@ registerBlockType( 'editorial/photoessay', {
 				<div className="wp-block-editorial-photoessay">
 					<div className={ layout }>
 						<InnerBlocks
-							templateLock="all"
 							allowedBlocks={ [ 'editorial/photoessay-image' ] }
 							templateInsertUpdatesSelection={ false }
 						/>


### PR DESCRIPTION
After one of the changes in the last several releases of Gutenberg, this appears to now be enforced during the automatic insertion of a block.

With this enabled on the inner blocks, no layout change would do anything other than replace the first block.