### PR TITLE
Jeremy / Use post date as pre-formatted in related stories list

### DIFF
--- a/src/blocks/relatedstories/relatedstories.js
+++ b/src/blocks/relatedstories/relatedstories.js
@@ -50,11 +50,6 @@ const {
 } = wp.url;
 
 const {
-	format,
-	__experimentalGetSettings, // Used to retrieve date format, watch for deprecation.
-} = wp.date;
-
-const {
 	apiFetch,
 } = wp;
 
@@ -313,7 +308,7 @@ registerBlockType( 'editorial/relatedstories', {
 							<h4 className="wp-block-editorial-relatedstories-article-title">
 								<a href={ post.link } className="wp-block-editorial-relatedstories-article-title-link">{ decodeEntities( post.title ) }</a>
 							</h4>
-							<p className="wp-block-editorial-relatedstories-article-date">{ format( __experimentalGetSettings().formats.date, post.date_gmt ) }</p>
+							<p className="wp-block-editorial-relatedstories-article-date">{ post.date_gmt }</p>
 							{ applyFilters( 'buBlocks.relatedStories.displayListItem', '', post, currentPost ) }
 						</div>
 					</article>


### PR DESCRIPTION
I originally used `__experimentalGetSettings().formats.date` as a way of retrieving the expected format in which the date should be displayed. It seems that I missed the date was already being provided through the post data in the expected format, so the use of `format()` and `__experimentalGetSettings()` is not necessary here.

I've tested this in both the WP 4.9 and WP 5.2.2 environments and the date displays as expected.