### PR TITLE
Jeremy / Only call `onChange` on Background component if it exists as a function

### DIFF
--- a/src/components/background/index.js
+++ b/src/components/background/index.js
@@ -166,8 +166,11 @@ function Background( props ) {
 			backgroundCaption: media.caption,
 		} );
 
-		// Let the block code take care of any further handling.
-		props.onChange( media, mediaType );
+		// If an `onChange` attribute is part of the Background component, ensure
+		// that fires as expected.
+		if ( 'function' === typeof props.onChange ) {
+			props.onChange( media, mediaType );
+		}
 	};
 
 	// Set attributes based on a selected URL.


### PR DESCRIPTION
In the latest version of WordPress and Gutenberg, it's possible the `onChange` function does not exist by default on block components.

This change checks that `onChange` is callable before attempting to call it in custom handling for the `Background` component.

This will likely be fixed in future versions of Gutenberg via https://github.com/WordPress/gutenberg/pull/17036, but it won't hurt to have a fallback check here.