### PR TITLE
Jeremy / Adjust application of layout as templates to Photo Essay block

### DIFF
--- a/src/blocks/photoessay/photoessay.js
+++ b/src/blocks/photoessay/photoessay.js
@@ -114,14 +114,14 @@ registerBlockType( 'editorial/photoessay', {
 		// ensure one photoessay-image block is added to the template.
 		if ( layout === '' ) {
 			setAttributes( { layout: 'photo-row-thirds-3' } );
-			photoTemplate.push( [ 'editorial/photoessay-image' ] );
+			photoTemplate.push( [ 'editorial/photoessay-image', { columnClass: 'photo-3' } ] );
 		} else {
 			const blockClasses = layout.split( '-' ).splice( 3 );
 
 			// Ensure the photoessay template for this block contains enough
 			// room for the number of expected photoessay-image blocks.
 			blockClasses.forEach( ( blockClass, i ) => {
-				photoTemplate.push( [ 'editorial/photoessay-image' ] );
+				photoTemplate.push( [ 'editorial/photoessay-image', { columnClass: `photo-${blockClass}` } ] );
 			} );
 		}
 


### PR DESCRIPTION
This is a replacement for #201, which removed template locking on the Photo Essay block to allow layout changes, but caused the side effect of being able to remove blocks from the template.

The approach in this PR makes use of templates to apply layout changes as they are made. Based on the layout attribute assigned to the Photo Essay block, we can build a dynamic-ish template to assign to the block as it is rendered for edit. This is pretty straight forward because only one block type is allowed, `photoessay-image`, and only one attribute _really_ matters by default, `columnClass`.

In 5.2.2 + Gutenberg 6.3
* [x] Layout changes work as expected
* [x] Class name changes on `photoessay-image` blocks work as expected
* [x] Selected images are retained even as layout changes
* [x] Extra blocks are removed when the layout contains fewer than currently exist

In current production environment (4.9 + Gutenberg)
* [x] Layout changes work as expected
* [x] Class name changes on `photoessay-image` blocks work as expected
* [x] Selected images are retained even as layout changes
* [x] Extra blocks are removed when the layout contains fewer than currently exist