### PR TITLE
Only use editor settings when block level settings are unavailable

### DIFF
--- a/src/global/theme-options.js
+++ b/src/global/theme-options.js
@@ -20,21 +20,30 @@ const {
 // Populate selectors that were in core/editor until WordPress 5.2 and are
 // now located in core/block-editor.
 const {
-	getSettings,
+	getSettings, // Note that getSettings is _not_ available until WordPress 5.2 and will be undefined otherwise.
 } = ( 'undefined' === typeof select( 'core/block-editor' ) ) ? select( 'core/editor' ) : select( 'core/block-editor' );
 
 // Populate actions that were in core/editor until WordPress 5.2 and are
 // now located in core/block-editor.
 const {
-	updateSettings,
+	updateSettings, // Note that updateSettings is _not_ available until WordPress 5.2 and will be undefined otherwise.
 } = ( 'undefined' === typeof dispatch( 'core/block-editor' ) ) ? dispatch( 'core/editor' ) : dispatch( 'core/block-editor' );
 
 import publicationSlug from './publication-slug';
 
 const themeOptions = () => {
+	let defaultColors;
+
 	// Get the default colors as set by the block editor and in the theme
 	// through `add_theme_support()`.
-	const defaultColors = getSettings().colors;
+	//
+	// getSettings is used in WordPress 5.2 and later.
+	// getEditorSettings is used in WordPress 4.9 + Gutenberg.
+	if ( 'undefined' === typeof getSettings ) {
+		defaultColors = getEditorSettings().colors;
+	} else {
+		defaultColors = getSettings().colors;
+	}
 
 	// Get default theme color options set by the active theme through the
 	// `block_editor_settings` filter in PHP.
@@ -65,7 +74,12 @@ const themeOptions = () => {
 		// Update both the editor settings and general settings so that when a color
 		// is chosen, the value is one of those expected by the component.
 		updateEditorSettings( { colors: newColors } );
-		updateSettings( { colors: newColors } );
+
+		// In WordPress 5.2 and alter, the settings should be updated outside of the
+		// editor too, through updateSettings.
+		if ( 'undefined' !== typeof updateSettings ) {
+			updateSettings( { colors: newColors } );
+		}
 	}
 
 	// Return the array of custom color objects for passing to the `colors` prop.


### PR DESCRIPTION
In WordPress 5.2, several pieces of Gutenberg were split into block editor components as a way of indicating they could be used outside of the standard editor. See #177 for initial work on this repo to adapt to that.

This commit adds some fallbacks to use `getEditorSettings()` and `updateEditorSettings()` as normal when `getSettings()` and `updateSettings()` are not yet available.