### PR TITLE
Lock KSS to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grunt-kss": "^5.0.1",
     "grunt-wp-i18n": "^1.0.2",
     "grunt-wp-readme-to-markdown": "~1.0.0",
-    "id-kss-builder": "git+ssh://git@github.com:bu-ist/id-kss-builder#develop",
+    "id-kss-builder": "git+ssh://git@github.com:bu-ist/id-kss-builder#1.0.0",
     "responsive-foundation": "git@github.com:bu-ist/responsive-foundation.git#develop"
   }
 }


### PR DESCRIPTION
Locks ID KSS Builder to the 1.0.0 release. The next release will be safe to upgrade to in this repo - feel free to do so whenever you're ready.