### PR TITLE
removing unused filter

### DIFF
--- a/src/blocks/photoessay/photoessay-image.js
+++ b/src/blocks/photoessay/photoessay-image.js
@@ -42,12 +42,6 @@ const {
 } = wp.compose;
 
 
-// Filter the block wrapper component with the `addColumnClassName` function.
-addFilter(
-	'editor.BlockListBlock',
-	'bu-blocks/column-class-name',
-);
-
 // Register the block.
 registerBlockType( 'editorial/photoessay-image', {
 	title: __( 'Photo Essay Image' ),


### PR DESCRIPTION
The related `addColumnClassName` function was removed Sept 4th 2019 by Charlie in this commit:
https://github.com/bu-ist/bu-blocks/commit/a6e40973b15cd785cb25ca19bf368b868cb78108#diff-848fe56270fd44a92734e7d9908f3682

This `addFilter()` call is causing an error to appear in the console in production and it doesn’t seem that we need this here anymore.