### PR TITLE
Modal block editor style fixes for 5.4

### DIFF
--- a/dist/blocks.editor.build.css
+++ b/dist/blocks.editor.build.css
@@ -9820,11 +9820,11 @@ div[data-type="editorial/aside"] .wp-block-editorial-aside {
  * which makes it higher in priority.
  */
 [data-selected-modal="true"] .wp-block-editorial-modal-content {
-  display: block; }
+  display: block !important; }
 
 .wp-block-editorial-modal-callout,
 .wp-block-editorial-modal-content {
-  float: none; }
+  float: none !important; }
 
 .wp-block-editorial-modal-callout .editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce,
 .wp-block-editorial-modal-callout .block-editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .block-editor-rich-text__tinymce {

--- a/src/blocks/modal/editor.scss
+++ b/src/blocks/modal/editor.scss
@@ -6,12 +6,12 @@
  */
 
 [data-selected-modal="true"] .wp-block-editorial-modal-content {
-	display: block;
+	display: block !important;
 }
 
 .wp-block-editorial-modal-callout,
 .wp-block-editorial-modal-content {
-	float: none;
+	float: none !important;
 }
 
 .wp-block-editorial-modal-callout .editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce,


### PR DESCRIPTION
an easy fix, increasing specificity of selector ensures the modal block's content div is visible when the block is selected now. 