### PR TITLE
Bug/fix loading frontend stylesheet in wp 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- fix stylesheet loading in WP 5.x. This wasn't noticed earlier as the current implementations of the plugin load the plugin
+stylesheet via the child theme. This fixes the block styling when BU-Blocks is activated on a Responsive Framework site. 
+
 ## 0.3.1
 - Photo Essay Block Improvements: 
   - Puts captions blocks closer to photo essay blocks. fixes: bu-ist/r-editorial#984

--- a/bu-blocks.php
+++ b/bu-blocks.php
@@ -7,7 +7,7 @@
  * Author URI:      http://www.bu.edu/interactive-design/
  * Text Domain:     bu-blocks
  * Domain Path:     /languages
- * Version:         0.2.20
+ * Version:         0.3.1
  *
  * @package         BU_Blocks
  */
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Defines the plugin version.
-define( 'BU_BLOCKS_VERSION', '0.2.20' );
+define( 'BU_BLOCKS_VERSION', '0.3.1' );
 
 /**
  * Displays admin notice and prevents activation.

--- a/src/init.php
+++ b/src/init.php
@@ -94,7 +94,7 @@ function enqueue_bu_blocks_general_stylesheet() {
 	wp_enqueue_style(
 		'bu-blocks-css', // Handle.
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ), // Block style CSS.
-		array( 'wp-blocks' ), // Dependency to include the CSS after it.
+		array(), // Dependency to include the CSS after it.
 		filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: filemtime — Gets file modification time.
 	);
 }


### PR DESCRIPTION
I noticed in the BU Blocks demo site ( http://id-demos.cms-devl.bu.edu/bu-blocks/photo-essay/ )that CSS for BU-Blocks is no longer being loaded on the frontend after the upgrade to 5.4. We didn't notice this in custom child themes because we load the block styles via the theme stylesheet. 

This PR fixes the issue by removing the dependency value in the enqueue styles function. I don't think this is really needed and it must have changed after 5.0. I looked at some example articles on enqueuing CSS for your gutenberg plugin and they leave the dependency value empty. 🤷‍♂️ 

Now it works in my sandbox: http://id-dakota.cms-devl.bu.edu/bu-blocks/drawer/