### PR TITLE
Wp upgrade/5.7 collapsible block hidden content area bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   - Update Block to Block API 2 for 5.7 compatibility
     - Adjust how `is-style-preview` class is checked as `props.attributes.classname` is sometimes undefined.
   - Editor Styles: adjust editor styles and selectors to match new markup of Block API 2
+    - Increase specificity of editor styles overriding frontend styles so `.bu-block-collapsible-content` shows when block is selected. 
+      - May cause some issues in child themes with overrides. 
 - Collapsible Control Block: 
   - Update to Block API 2, styling fixes for 5.7, fix center aligned styles.
   - add Editor.scss and Style.scss files that were missing and better styling for the block

--- a/src/blocks/collapsible/_bu-blocks-block-collapsible-base.scss
+++ b/src/blocks/collapsible/_bu-blocks-block-collapsible-base.scss
@@ -11,6 +11,10 @@
 .wp-block-bu-collapsible {
 	margin-top: -1px;
 
+	// Todo: let's refactor this to use :where() and drop the specificity so themes can overwrite it easier?
+	// Also could refactor this block to use Grid, 1 column wide and 1 row tall
+	// Then when open change grid layout to 1 column wide and 2 rows tall to show this content div.
+	// The core Accordion block is using that layout technique to show/hide the content area.
 	.bu-block-collapsible-content {
 		display: none;
 		padding: 20px;

--- a/src/blocks/collapsible/editor.scss
+++ b/src/blocks/collapsible/editor.scss
@@ -21,6 +21,9 @@
 }
 
 // Open state, when block is selected or has a child block selected
+// This has to be higher specificity than the frontend styles when loaded via `add_editor_style()`.
+// This is because in WordPress 5.7 the Editor Styles are still Prefixed with a class of `.editor-styles-wrapper`
+// That bumps up the specificity. Later versions of WP fix this by using :where() for Editor Styles.
 [data-type="bu/collapsible"].wp-block-bu-collapsible.is-selected,
 [data-type="bu/collapsible"].wp-block-bu-collapsible.has-child-selected {
 

--- a/src/blocks/collapsible/editor.scss
+++ b/src/blocks/collapsible/editor.scss
@@ -21,8 +21,8 @@
 }
 
 // Open state, when block is selected or has a child block selected
-.wp-block-bu-collapsible.is-selected,
-.wp-block-bu-collapsible.has-child-selected {
+[data-type="bu/collapsible"].wp-block-bu-collapsible.is-selected,
+[data-type="bu/collapsible"].wp-block-bu-collapsible.has-child-selected {
 
 	& > .bu-block-collapsible-content {
 		display: block;
@@ -66,10 +66,6 @@
 
 	.bu-collapsible-heading {
 		margin: 0;
-	}
-
-	.bu-block-collapsible-content {
-
 	}
 
 	&.is-style-preview {


### PR DESCRIPTION
Fixes: https://github.com/bu-ist/r-editorial/issues/1091

- Increases specificity of editor styles so the collapsible block's content area is shown when the block is selected. Not a great fix but temporary until the block is refactored and cleaned up for WP 5.8 or after. 