### PR TITLE
Fix dot position for End of Article Paragraph block style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
   - Update Buniverse Block to Block API 2 for 5.7 compatibility
   - Move TextControl for video id from editor to sidebar to aid in styling block when floated
   - Editor Styles: Add CSS4 Variable `--bu_blocks-block-bu-buniverse-editor-floated-width` so themes can adjust floated width easily
+  - Fix dot position for End of Article Paragraph block style.
 
 
 

--- a/src/components/paragraph-end-of-article-style/_bu-blocks-component-end-of-article-base.scss
+++ b/src/components/paragraph-end-of-article-style/_bu-blocks-component-end-of-article-base.scss
@@ -5,5 +5,6 @@
 	}
 	&::after {
 		font-size: 0.6em;
+		position: static;
 	}
 }


### PR DESCRIPTION
[#1089](https://github.com/bu-ist/r-editorial/issues/1089)
This change addresses issues with the End of Article Paragraph block style. The problem being that in the WP5.7 Block Editor adds styles to the `.editor-styles-wrapper .is-style-end-of-article::after`. This is intended for creating focus outlines on blocks that do not contain `contenteditable="true"`. Since Paragraph Blocks do contain `contenteditable="true"` the `:after` pseudo element can be used for other purposes.


- [Sandbox Link](https://id-seant-upgrade.cms-devl.bu.edu/wp-admin/post.php?post=435086&action=edit)

#### Afflicted Block
<img width="996" height="264" alt="image" src="https://github.com/user-attachments/assets/12b18aaa-342c-46b3-8f69-0504c5336309" />

#### Fixed Block
<img width="972" height="282" alt="image" src="https://github.com/user-attachments/assets/f495ef92-c598-4915-81bc-aed9643e1b10" />