### PR TITLE
Bug: BU Pullquote Block - remove withColors() and refactor for 5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bug: BU Pullquote Block - remove withColors() and refactor for 5.8 see: https://github.com/bu-ist/bu-blocks/pull/448
+
 ## 0.4.2
 
 -   Related Stories block was crashing in the editor when users were trying to access style options. This is a known bug in older gutenberg versions. Fixed by adding optional example. Details about error and eventual fix for later gutenberg issues can he found here: https://github.com/WordPress/gutenberg/pull/29894

--- a/src/blocks/pullquote/pullquote.js
+++ b/src/blocks/pullquote/pullquote.js
@@ -31,10 +31,8 @@ const {
 } = wp.element;
 const {
 	PanelBody,
-	Path,
 	SelectControl,
 	TextControl,
-	SVG,
 } = wp.components;
 const {
 	InspectorControls,
@@ -56,6 +54,8 @@ const isStyleDefault = ( className ) => {
  * @param {number} backgroundId ID of the background media, if set.
  * @param {string} imageFocus   Value of the "Crop Media To" setting.
  * @param {string} themeColor   Value of the "Theme Color" setting.
+ * @param {string} textColor   Value of the "Text Color" setting.
+ * @returns {string} The class list for the block.
  */
 const getClasses = ( className, backgroundId, imageFocus, themeColor, textColor ) => {
 	const isStylePop = className.includes( 'is-style-pop' );
@@ -65,13 +65,13 @@ const getClasses = ( className, backgroundId, imageFocus, themeColor, textColor 
 			className,
 			{
 				'has-image': ( backgroundId && ! isStylePop ),
-				[ `has-image-focus-${imageFocus}` ]: ( imageFocus && ! isStylePop ),
-				[ `has-${themeColor}-theme` ]: themeColor,
-				[ `has-${textColor}-theme-text` ]: textColor,
+				[ `has-image-focus-${ imageFocus }` ]: ( imageFocus && ! isStylePop ),
+				[ `has-${ themeColor }-theme` ]: themeColor,
+				[ `has-${ textColor }-theme-text` ]: textColor,
 			}
 		)
 	);
-}
+};
 
 // Only allow images in the background component for this block.
 const allowedMedia = [ 'image' ];
@@ -80,7 +80,7 @@ const allowedMedia = [ 'image' ];
 registerBlockType( 'bu/pullquote', {
 	title: __( 'BU Pullquote' ),
 	description: __( '' ),
-	icon: blockIcons('pullquote'),
+	icon: blockIcons( 'pullquote' ),
 	category: 'bu',
 	supports: {
 		align: [ 'full', 'wide' ],
@@ -89,7 +89,7 @@ registerBlockType( 'bu/pullquote', {
 		quote: {
 			type: 'array',
 			source: 'children',
-			selector: '.quote-sizing'
+			selector: '.quote-sizing',
 		},
 		photoCredit: {
 			type: 'string',
@@ -99,11 +99,11 @@ registerBlockType( 'bu/pullquote', {
 		cite: {
 			type: 'array',
 			source: 'children',
-			selector: 'footer'
+			selector: 'footer',
 		},
 		imageFocus: {
 			type: 'string',
-			default: 'center-middle'
+			default: 'center-middle',
 		},
 		className: {
 			type: 'string',
@@ -133,7 +133,6 @@ registerBlockType( 'bu/pullquote', {
 			label: __( 'Pop' ),
 		},
 	],
-	// Define the block edit function without withColors HOC
 	edit: ( props => {
 		// Get the block properties.
 		const {
@@ -191,9 +190,6 @@ registerBlockType( 'bu/pullquote', {
 			);
 		};
 
-		console.log( `pullquote themeColor`, themeColor, themeColorObj );
-		console.log( `pullquote textColor`, textColor, textColorObj );
-
 		// Return the block editing interface.
 		return (
 			<Fragment>
@@ -201,7 +197,7 @@ registerBlockType( 'bu/pullquote', {
 					<PanelBody title={ __( 'Media Options' ) } >
 						<TextControl
 							label={ __( 'Media Credit' ) }
-							onChange={ photoCredit => setAttributes( { photoCredit } ) }
+							onChange={ value => setAttributes( { photoCredit: value } ) }
 							value={ photoCredit }
 						/>
 					</PanelBody>

--- a/src/blocks/pullquote/pullquote.js
+++ b/src/blocks/pullquote/pullquote.js
@@ -27,6 +27,7 @@ const {
 const {
 	Fragment,
 	useState,
+	useMemo,
 } = wp.element;
 const {
 	PanelBody,
@@ -153,11 +154,11 @@ registerBlockType( 'bu/pullquote', {
 		} = attributes;
 
 		// Get color palette from themeOptions
-		const colors = themeOptions();
+		const colors = useMemo( () => themeOptions(), [] );
 
 		// Resolve color objects from slugs using WordPress built-in function
-		const themeColorObj = getColorObjectByAttributeValues( colors, themeColor );
-		const textColorObj = getColorObjectByAttributeValues( colors, textColor );
+		const themeColorObj = useMemo( () => getColorObjectByAttributeValues( colors, themeColor ), [ colors, themeColor ] );
+		const textColorObj = useMemo( () => getColorObjectByAttributeValues( colors, textColor ), [ colors, textColor ] );
 
 		const [ isUploading, setIsUploading ] = useState( false );
 
@@ -213,9 +214,9 @@ registerBlockType( 'bu/pullquote', {
 								onChange: ( value ) => {
 									// Get the color object from the selected color value.
 									const newValueColorObj = getColorObjectByColorValue( colors, value );
-									// Set the attribute to the new color slug or undefined if not found.
+									// Set the attribute to the new color slug or an empty string if not found.
 									setAttributes( {
-										themeColor: newValueColorObj ? newValueColorObj.slug : undefined,
+										themeColor: newValueColorObj ? newValueColorObj.slug : '',
 									} );
 								},
 								label: __( 'Theme' ),
@@ -232,9 +233,9 @@ registerBlockType( 'bu/pullquote', {
 								onChange: ( value ) => {
 									// Get the color object from the selected color value.
 									const newValueColorObj = getColorObjectByColorValue( colors, value );
-									// Set the attribute to the new color slug or undefined if not found.
+									// Set the attribute to the new color slug or an empty string if not found.
 									setAttributes( {
-										textColor: newValueColorObj ? newValueColorObj.slug : undefined,
+										textColor: newValueColorObj ? newValueColorObj.slug : '',
 									} );
 								},
 								label: __( 'Text Color' ),

--- a/src/blocks/pullquote/pullquote.js
+++ b/src/blocks/pullquote/pullquote.js
@@ -39,7 +39,8 @@ const {
 	InspectorControls,
 	PanelColorSettings,
 	RichText,
-	withColors,
+	getColorObjectByAttributeValues,
+	getColorObjectByColorValue,
 } = ( 'undefined' === typeof wp.blockEditor ) ? wp.editor : wp.blockEditor;
 
 // Returns true if the current block style is "Default".
@@ -131,17 +132,13 @@ registerBlockType( 'bu/pullquote', {
 			label: __( 'Pop' ),
 		},
 	],
-
-	edit: withColors( 'themeColor', 'textColor' )( props => {
+	// Define the block edit function without withColors HOC
+	edit: ( props => {
 		// Get the block properties.
 		const {
 			attributes,
 			setAttributes,
 			className,
-			setThemeColor,
-			themeColor,
-			textColor,
-			setTextColor,
 		} = props;
 
 		// Get the block attributes.
@@ -151,7 +148,16 @@ registerBlockType( 'bu/pullquote', {
 			photoCredit,
 			imageFocus,
 			backgroundId,
+			themeColor,
+			textColor,
 		} = attributes;
+
+		// Get color palette from themeOptions
+		const colors = themeOptions();
+
+		// Resolve color objects from slugs using WordPress built-in function
+		const themeColorObj = getColorObjectByAttributeValues( colors, themeColor );
+		const textColorObj = getColorObjectByAttributeValues( colors, textColor );
 
 		const [ isUploading, setIsUploading ] = useState( false );
 
@@ -184,6 +190,9 @@ registerBlockType( 'bu/pullquote', {
 			);
 		};
 
+		console.log( `pullquote themeColor`, themeColor, themeColorObj );
+		console.log( `pullquote textColor`, textColor, textColorObj );
+
 		// Return the block editing interface.
 		return (
 			<Fragment>
@@ -200,11 +209,18 @@ registerBlockType( 'bu/pullquote', {
 						initialOpen={ false }
 						colorSettings={ [
 							{
-								value: themeColor.color,
-								onChange: setThemeColor,
+								value: themeColorObj ? themeColorObj.color : undefined,
+								onChange: ( value ) => {
+									// Get the color object from the selected color value.
+									const newValueColorObj = getColorObjectByColorValue( colors, value );
+									// Set the attribute to the new color slug or undefined if not found.
+									setAttributes( {
+										themeColor: newValueColorObj ? newValueColorObj.slug : undefined,
+									} );
+								},
 								label: __( 'Theme' ),
 								disableCustomColors: true,
-								colors: themeOptions(),
+								colors: colors,
 							},
 						] }
 					/>
@@ -212,11 +228,18 @@ registerBlockType( 'bu/pullquote', {
 						title={ __( 'Text Color' ) }
 						colorSettings={ [
 							{
-								value: textColor.color,
-								onChange: setTextColor,
+								value: textColorObj ? textColorObj.color : undefined,
+								onChange: ( value ) => {
+									// Get the color object from the selected color value.
+									const newValueColorObj = getColorObjectByColorValue( colors, value );
+									// Set the attribute to the new color slug or undefined if not found.
+									setAttributes( {
+										textColor: newValueColorObj ? newValueColorObj.slug : undefined,
+									} );
+								},
 								label: __( 'Text Color' ),
 								disableCustomColors: true,
-								colors: themeOptions(),
+								colors: colors,
 							},
 
 						] }
@@ -229,7 +252,8 @@ registerBlockType( 'bu/pullquote', {
 					placeholderText={ __( 'Add Image' ) }
 					setIsUploading={ setIsUploading }
 				/>
-				<div className={ getClasses( className, backgroundId, imageFocus, themeColor.slug, textColor.slug ) }>
+
+				<div className={ getClasses( className, backgroundId, imageFocus, themeColor, textColor ) }>
 					<div className="wp-block-bu-pullquote-inner">
 						{ isStyleDefault( className ) && (
 							<Fragment>


### PR DESCRIPTION
- remove withColors() HOC
- move themeColor and textColor variables to attribute destructuring
- Setup variables for storing the color palette
- use core functions to get the color object from the color palette by passing the selected themeColor or textColor
- in ColorPalette component set the themeColor and textColor attributes directly
- in getClasses() use themeColor or textColor directly which should contain a slug (class name) of the color.