### PR TITLE
Bug/5.8 withcolors aside block fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+### WordPress 5.8 Compatibility: 
+- Bug: Aside Block - remove withColors() and refactor for 5.8.
 - Bug: BU Pullquote Block - remove withColors() and refactor for 5.8 see: https://github.com/bu-ist/bu-blocks/pull/448
+
 
 ## 0.4.2
 

--- a/src/blocks/aside/aside.js
+++ b/src/blocks/aside/aside.js
@@ -33,7 +33,7 @@ const asideBlock = registerBlockType( 'editorial/aside', {
 	apiVersion: 2,
 	title: __( 'Aside' ),
 	description: __( 'Add an aside with related information. Accepts image, headline, paragraph, and button blocks as children.' ),
-	icon: blockIcons('aside'),
+	icon: blockIcons( 'aside' ),
 	category: 'bu-editorial',
 	supports: {
 		align: [ 'left', 'right' ],
@@ -56,10 +56,10 @@ const asideBlock = registerBlockType( 'editorial/aside', {
 
 		const blockProps = useBlockProps.save( {
 			className: classes,
-		});
+		} );
 
 		return (
-			<aside {...blockProps}>
+			<aside { ...blockProps }>
 				<InnerBlocks.Content />
 			</aside>
 		);
@@ -70,7 +70,7 @@ const presetTemplate = [
 	[ 'core/image' ],
 	[ 'core/heading', { placeholder: 'Enter aside title…' } ],
 	[ 'core/paragraph', { placeholder: 'Enter aside content…' } ],
-	[ 'core/button' ]
+	[ 'core/button' ],
 ];
 
 RegisterBlockPreset( asideBlock, presetTemplate );

--- a/src/blocks/aside/edit.js
+++ b/src/blocks/aside/edit.js
@@ -11,61 +11,71 @@ import allowedBlocks from '../../components/allowed-blocks';
 
 // WordPress dependencies.
 const { __ } = wp.i18n;
-const { Component, Fragment } = wp.element;
-const { compose } = wp.compose;
+const { Fragment, useMemo } = wp.element;
 const {
 	InnerBlocks,
 	InspectorControls,
 	PanelColorSettings,
-	withColors,
-	useBlockProps
+	useBlockProps,
+	getColorObjectByAttributeValues,
+	getColorObjectByColorValue,
 } = ( 'undefined' === typeof wp.blockEditor ) ? wp.editor : wp.blockEditor;
 
-const BUAsideEdit = ( props ) => {
+export default function Edit( props ) {
+	const {
+		attributes,
+		className,
+		presetTemplate,
+		setAttributes,
+	} = props;
 
-		const {
-			attributes,
-			className,
-			themeColor,
-			setThemeColor,
-			presetTemplate,
-		} = props;
+	const { themeColor } = attributes;
 
-		const classes = classnames(
-			className,
-			{ [ `has-${themeColor.slug}-background` ]: themeColor.slug }
-		);
+	const classes = classnames(
+		className,
+		{ [ `has-${ themeColor }-background` ]: themeColor }
+	);
 
-		const blockProps = useBlockProps( {
-			className: classes,
-		});
+	const blockProps = useBlockProps( {
+		className: classes,
+	} );
 
-		return (
-			<Fragment>
-				<InspectorControls>
-					<PanelColorSettings
-						title={ __( 'Color Settings' ) }
-						colorSettings={ [
-							{
-								value: themeColor.color,
-								onChange: setThemeColor,
-								label: __( 'Theme' ),
-								disableCustomColors: true,
-								colors: themeOptions(),
+	// themOptions() returns the full/global color palette added to editor settings.
+	const themeOptionsPalette = useMemo( () => themeOptions(), [] );
+
+	// Resolve color objects from slugs using WordPress built-in function
+	const themeColorObj = useMemo( () => getColorObjectByAttributeValues( themeOptionsPalette, themeColor ), [ themeOptionsPalette, themeColor ] );
+
+	return (
+		<Fragment>
+			<InspectorControls>
+				<PanelColorSettings
+					title={ __( 'Color Settings' ) }
+					colorSettings={ [
+						{
+							value: themeColorObj ? themeColorObj.color : undefined,
+							onChange: ( value ) => {
+								// Get the color object from the selected color value.
+								const newValueColorObj = getColorObjectByColorValue( themeOptionsPalette, value );
+								// Set the attribute to the new color slug or an empty string if not found.
+								setAttributes( {
+									themeColor: newValueColorObj ? newValueColorObj.slug : '',
+								} );
 							},
-						] }
-					/>
-				</InspectorControls>
-				<aside {...blockProps}>
-					<InnerBlocks
-						allowedBlocks={ allowedBlocks() }
-						template={ presetTemplate }
-					/>
-				</aside>
-			</Fragment>
-		);
+							label: __( 'Theme' ),
+							disableCustomColors: true,
+							colors: themeOptionsPalette,
+						},
+					] }
+				/>
+			</InspectorControls>
+			<aside { ...blockProps }>
+				<InnerBlocks
+					allowedBlocks={ allowedBlocks() }
+					template={ presetTemplate }
+				/>
+			</aside>
+		</Fragment>
+	);
 }
 
-export default compose( [
-	withColors( 'themeColor' )
-] )( BUAsideEdit );

--- a/src/blocks/aside/edit.js
+++ b/src/blocks/aside/edit.js
@@ -40,7 +40,7 @@ export default function Edit( props ) {
 		className: classes,
 	} );
 
-	// themOptions() returns the full/global color palette added to editor settings.
+	// themeOptions() returns the full/global color palette added to editor settings.
 	const themeOptionsPalette = useMemo( () => themeOptions(), [] );
 
 	// Resolve color objects from slugs using WordPress built-in function

--- a/src/blocks/pullquote/pullquote.js
+++ b/src/blocks/pullquote/pullquote.js
@@ -153,11 +153,11 @@ registerBlockType( 'bu/pullquote', {
 		} = attributes;
 
 		// Get color palette from themeOptions
-		const colors = useMemo( () => themeOptions(), [] );
+		const themeOptionsPalette = useMemo( () => themeOptions(), [] );
 
 		// Resolve color objects from slugs using WordPress built-in function
-		const themeColorObj = useMemo( () => getColorObjectByAttributeValues( colors, themeColor ), [ colors, themeColor ] );
-		const textColorObj = useMemo( () => getColorObjectByAttributeValues( colors, textColor ), [ colors, textColor ] );
+		const themeColorObj = useMemo( () => getColorObjectByAttributeValues( themeOptionsPalette, themeColor ), [ themeOptionsPalette, themeColor ] );
+		const textColorObj = useMemo( () => getColorObjectByAttributeValues( themeOptionsPalette, textColor ), [ themeOptionsPalette, textColor ] );
 
 		const [ isUploading, setIsUploading ] = useState( false );
 
@@ -209,7 +209,7 @@ registerBlockType( 'bu/pullquote', {
 								value: themeColorObj ? themeColorObj.color : undefined,
 								onChange: ( value ) => {
 									// Get the color object from the selected color value.
-									const newValueColorObj = getColorObjectByColorValue( colors, value );
+									const newValueColorObj = getColorObjectByColorValue( themeOptionsPalette, value );
 									// Set the attribute to the new color slug or an empty string if not found.
 									setAttributes( {
 										themeColor: newValueColorObj ? newValueColorObj.slug : '',
@@ -217,7 +217,7 @@ registerBlockType( 'bu/pullquote', {
 								},
 								label: __( 'Theme' ),
 								disableCustomColors: true,
-								colors: colors,
+								colors: themeOptionsPalette,
 							},
 						] }
 					/>
@@ -228,7 +228,7 @@ registerBlockType( 'bu/pullquote', {
 								value: textColorObj ? textColorObj.color : undefined,
 								onChange: ( value ) => {
 									// Get the color object from the selected color value.
-									const newValueColorObj = getColorObjectByColorValue( colors, value );
+									const newValueColorObj = getColorObjectByColorValue( themeOptionsPalette, value );
 									// Set the attribute to the new color slug or an empty string if not found.
 									setAttributes( {
 										textColor: newValueColorObj ? newValueColorObj.slug : '',
@@ -236,7 +236,7 @@ registerBlockType( 'bu/pullquote', {
 								},
 								label: __( 'Text Color' ),
 								disableCustomColors: true,
-								colors: colors,
+								colors: themeOptionsPalette,
 							},
 
 						] }


### PR DESCRIPTION
- Aside block: remove withColors() HOC and refactor to get themeColor working again
- Renamed themeOptions() variable name in Pullquote block to avoid confusion with default `colors` palette WP provides.  

Builds on the fix found for Pullquote block in previous PR: https://github.com/bu-ist/bu-blocks/pull/448