### PR TITLE
Dakota/5.8 refactor pullquote revisions

### DIFF
--- a/src/blocks/blocks-bundled.scss
+++ b/src/blocks/blocks-bundled.scss
@@ -29,3 +29,4 @@
 @import 'headline/bu-blocks-block-headline-base';
 @import 'introparagraph/bu-blocks-block-introparagraph-base';
 @import 'leadin/bu-blocks-block-leadin-base';
+@import 'pullquote/bu-blocks-block-pullquote-base';

--- a/src/blocks/pullquote/Readme.md
+++ b/src/blocks/pullquote/Readme.md
@@ -1,0 +1,72 @@
+# Pullquote Block
+
+The BU Pullquote block provides a stylized pullquote that significantly expands on the WordPress core pullquote block. While originally designed for editorial content, it can be used across various content types and post formats.
+
+### Enhanced Features
+- **Background Media Support**: Add images or videos as background media with customizable opacity and focal point controls
+- **Multiple Block Styles**: Three distinct visual styles (Default, Modern, Pop)
+- **Photo Credits**: Built-in field for attributing background media
+- **Advanced Media Controls**: 
+  - Background image focal point selection (9-position grid)
+  - Video background with autoplay option
+  - Media opacity controls (0-100%)
+  - Caption/alt text support
+- **BU Color Themes**: Custom color theme system for brand consistency across editorial content
+- **Wide/Full Alignment**: Extended alignment options for impactful layouts
+- **Dynamic Rendering**: PHP-based template system allowing theme overrides
+
+
+## Block Supports
+
+### BU Blocks Color Themes
+Custom color theme system originally part of the Editorial Project functionality. Provides predefined theme colors for brand consistency.
+
+### Core WordPress Color Support
+Standard WordPress color controls for text, background, links, and gradients:
+```json
+"color": {
+    "text": true,
+    "background": true,
+    "link": true,
+    "gradients": true
+}
+```
+
+**Note:** Only one color system (BU Color Themes OR Core Color Support) should be used per theme. Both can be disabled via filters or theme.json.
+
+### Other Supports
+- **Alignment**: Full and wide alignment options
+- **Anchor**: Custom HTML anchor IDs
+- **HTML**: Disabled after conversion to a dynamic block template
+
+
+## ToDo
+
+### High Priority
+- **Class Name Migration**: Implement custom Block Support for prefixed class names following the migration plan in `class-name-migration-plan.md`
+  - Create `render-legacy.php` for backward compatibility
+  - Add `__bublocks_prefixed_classes` support to block.json
+  - Update Block Supports class to handle prefixed class detection
+  - Document theme migration path
+
+### Medium Priority
+- **Accessibility Improvements**: 
+  - Add ARIA labels for decorative elements
+  - Ensure proper semantic HTML structure for screen readers
+  - Test keyboard navigation within block settings
+- **Video Background Optimization**:
+  - Add poster image support for video backgrounds
+  - Implement lazy loading for video media
+
+
+### Low Priority
+- **Gradient Background Support**: Consider extend background options to include gradients alongside images/video
+
+## Changelog
+
+### 2.0.0
+ - Breaking Changes: 
+   - None known at this time.
+ - Added support for core `Color` Block Support
+ - Added support for custom `__bublocks_colorthemes` Block Support
+ - Refactor block structure to modernize

--- a/src/blocks/pullquote/_bu-blocks-block-pullquote-base.scss
+++ b/src/blocks/pullquote/_bu-blocks-block-pullquote-base.scss
@@ -31,12 +31,14 @@
 		position: relative;
 	}
 
-	figure {
+	figure,
+	figure.wp-block-bu-pullquote-background-media {
 		position: absolute;
 		top: 0;
 		left: 0;
 		width: 100%;
 		height: 100%;
+		margin: 0;
 	}
 	img {
 		object-fit: cover;

--- a/src/blocks/pullquote/block.json
+++ b/src/blocks/pullquote/block.json
@@ -13,6 +13,9 @@
 	"style": "file:./style.css",
 	"render": "file:./render.php",
 	"attributes": {
+		"anchor": {
+			"type": "string"
+		},
 		"quote": {
 			"type": "string",
 			"default": ""
@@ -79,7 +82,16 @@
 		}
 	],
 	"supports": {
-		"align": [ "full", "wide" ]
+		"align": [ "full", "wide" ],
+		"html": false,
+		"anchor": true,
+        "color": {
+            "text": true,
+            "background": true,
+            "link": true,
+            "gradients": true
+        },
+        "__bublocks_colorthemes": true
 	},
 	"example": {
 		"attributes": {

--- a/src/blocks/pullquote/class-name-migration-plan.md
+++ b/src/blocks/pullquote/class-name-migration-plan.md
@@ -1,0 +1,253 @@
+# Pullquote Block Class Name Migration Plan
+
+This is a possible solution, details written up by Claude. 
+
+## Problem Statement
+
+The pullquote block currently uses unprefixed class names (`container-lockup`, `container-text`, `caption`, etc.) that are too generic and could conflict with other styles. We need to migrate to prefixed class names (e.g., `wp-block-bu-pullquote-container-text`) while maintaining backward compatibility with existing sites that have custom theme styling targeting the old class names.
+
+**Constraints:**
+- Plugin is used on dozens of sites with custom themes
+- Each theme has CSS targeting the unprefixed class names
+- Cannot require coordinated updates across all sites
+- Cannot break existing content when plugin updates
+
+## Unprefixed Classes to Migrate
+
+1. `container-lockup` → `wp-block-bu-pullquote-container-lockup`
+2. `container-icon-outer` → `wp-block-bu-pullquote-container-icon-outer`
+3. `container-icon-inner` → `wp-block-bu-pullquote-container-icon-inner`
+4. `container-text` → `wp-block-bu-pullquote-container-text`
+5. `quote-sizing` → `wp-block-bu-pullquote-quote-sizing`
+6. `caption` → `wp-block-bu-pullquote-caption`
+
+Note: `wp-component-media-credit` is intentionally prefixed as a shared component class.
+
+## Recommended Solution: Custom Block Support
+
+Use WordPress Block Supports API (following existing patterns in this codebase for color/spacing supports).
+
+### Implementation Steps
+
+#### 1. Add Custom Support to block.json
+
+File: `src/blocks/pullquote/block.json`
+
+```json
+{
+  "supports": {
+    "align": ["full", "wide"],
+    "anchor": true,
+    "color": { /* ... */ },
+    "__bublocks_colorthemes": true,
+    "__bublocks_prefixed_classes": true
+  }
+}
+```
+
+**Default:** `true` (prefixed classes enabled by default for new themes)
+
+#### 2. Create Two Render Templates
+
+**File: `src/blocks/pullquote/render.php`**
+- Uses prefixed class names
+- For themes that support modern class names
+
+**File: `src/blocks/pullquote/render-legacy.php`**
+- Uses unprefixed class names (copy of current render.php)
+- For backward compatibility with existing themes
+
+#### 3. Extend Block Supports Class
+
+File: `includes/blocks/class-block-supports.php`
+
+Add method to `BlockSupports` class:
+
+```php
+public function setup() {
+    // Existing filters...
+    $colors_enabled = apply_filters( 'bu_blocks_supports_color', true );
+    $spacing_enabled = apply_filters( 'bu_blocks_supports_spacing', true );
+    
+    // New: Allow themes to disable prefixed classes
+    $prefixed_classes = apply_filters( 'bu_blocks_supports_prefixed_classes', true );
+    
+    if ( false === $prefixed_classes ) {
+        add_filter( 'block_type_metadata', array( $this, 'remove_prefixed_classes_support' ) );
+    }
+}
+
+public function remove_prefixed_classes_support( $metadata ) {
+    $registered_block_names = bu_blocks_get_registered_block_names();
+    
+    if ( ! isset( $metadata['name'] ) || ! in_array( $metadata['name'], $registered_block_names, true ) ) {
+        return $metadata;
+    }
+    
+    if ( isset( $metadata['supports']['__bublocks_prefixed_classes'] ) ) {
+        $metadata['supports']['__bublocks_prefixed_classes'] = false;
+    }
+    
+    return $metadata;
+}
+```
+
+#### 4. Update Render Callback
+
+File: `includes/blocks/class-blocks.php`
+
+Modify the render_callback to check block support:
+
+```php
+$block_options['render_callback'] = function ( $attributes, $content, $block ) use ( $block_folder_name ) {
+    ob_start();
+    
+    // Check if block supports prefixed classes
+    $block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'bu/pullquote' );
+    $use_prefixed = isset( $block_type->supports['__bublocks_prefixed_classes'] ) 
+        && $block_type->supports['__bublocks_prefixed_classes'];
+    
+    // Choose template based on support
+    $template = $use_prefixed ? 'render.php' : 'render-legacy.php';
+    
+    // Check for theme override first
+    $theme_override = get_stylesheet_directory() . '/block-render/' . $block_folder_name . '.php';
+    
+    if ( file_exists( $theme_override ) ) {
+        include $theme_override;
+    } else {
+        include __DIR__ . '/' . $block_folder_name . '/' . $template;
+    }
+    
+    return ob_get_clean();
+};
+```
+
+### Theme Migration Path
+
+#### For Existing Themes (Immediate - Upon Plugin Update)
+
+Themes must opt-out of prefixed classes using one of these methods:
+
+**Option A: Via theme.json** (Recommended for modern themes)
+
+```json
+{
+  "$schema": "https://schemas.wp.org/wp/6.0/theme.json",
+  "version": 2,
+  "settings": {
+    "blocks": {
+      "bu/pullquote": {
+        "supports": {
+          "__bublocks_prefixed_classes": false
+        }
+      }
+    }
+  }
+}
+```
+
+**Option B: Via Filter** (For themes without theme.json)
+
+In theme's `functions.php`:
+
+```php
+// Disable prefixed classes for all BU Blocks
+add_filter( 'bu_blocks_supports_prefixed_classes', '__return_false' );
+```
+
+**Option C: Block-Level Disable** (Granular control)
+
+```php
+add_filter( 'block_type_metadata', function( $metadata ) {
+    if ( $metadata['name'] === 'bu/pullquote' ) {
+        $metadata['supports']['__bublocks_prefixed_classes'] = false;
+    }
+    return $metadata;
+} );
+```
+
+#### For Theme Updates (Later - When Theme CSS is Updated)
+
+1. Update theme CSS to target new prefixed selectors:
+   ```scss
+   // Old (remove or keep for transition)
+   .container-text {
+       display: flex;
+   }
+   
+   // New (add)
+   .wp-block-bu-pullquote-container-text {
+       display: flex;
+   }
+   ```
+
+2. Remove the opt-out from theme.json or functions.php
+
+3. All blocks immediately render with prefixed classes
+
+#### For New Themes
+
+- Do nothing - prefixed classes are enabled by default
+- Style using prefixed selectors from the start
+
+### Advantages of This Approach
+
+✅ **Zero Breaking Changes** - Existing sites work without modification  
+✅ **Theme Control** - Each theme migrates on its own schedule  
+✅ **Progressive Enhancement** - New themes get best practices by default  
+✅ **Follows Existing Patterns** - Uses same Block Supports system as color/spacing  
+✅ **Standard WordPress API** - Uses official Block Supports mechanism  
+✅ **Block-Level Granularity** - Can be controlled per-block or globally  
+✅ **Clean Markup** - No dual-class bloat  
+✅ **Future Proof** - Easy to extend for other blocks
+
+### Alternative Approaches Considered
+
+#### Option A: Dual-Class Output
+Output both old and new classes simultaneously: `class="container-text wp-block-bu-pullquote-container-text"`
+
+**Pros:** Zero coordination, works with all themes immediately  
+**Cons:** HTML bloat (~180 bytes per block), permanent unless deprecated later. Themes would need to be updated to take advantage and then eventually remove this from the plugin. New themes may continue using the old class names for new code. 
+
+#### Option C: Per-Block Version Attribute
+Store `blockVersion` attribute on each block instance.
+
+**Pros:** Automatic detection per block  
+**Cons:** Locks blocks permanently to version - prevents theme CSS updates without bulk block updates
+
+#### Option I: Theme Support Declaration
+Use `add_theme_support('bu-blocks-prefixed-classes')` instead of Block Supports.
+
+**Pros:** Simpler than custom Block Support  
+**Cons:** Doesn't follow existing patterns, no theme.json integration. Can't be set per block.
+
+**Decision:** Option J (Custom Block Support) chosen for consistency with existing codebase patterns and maximum flexibility.
+
+### Documentation Requirements
+
+1. **Plugin Changelog** - Document new support and migration path
+2. **Block README** - Update `src/blocks/pullquote/Readme.md` with class name changes
+3. **Theme Migration Guide** - Create guide for theme developers with:
+   - List of old → new class names
+   - How to opt-out using theme.json or filter
+   - Example CSS migration patterns
+4. **Communication** - Notify theme maintainers before release
+
+### Testing Checklist
+
+- [ ] Block renders correctly with prefixed classes enabled
+- [ ] Block renders correctly with prefixed classes disabled (legacy mode)
+- [ ] Theme override in `/block-render/pullquote.php` still works
+- [ ] Filter `bu_blocks_supports_prefixed_classes` works globally
+- [ ] theme.json per-block disable works
+- [ ] Existing v1 static blocks continue working
+- [ ] Plugin CSS uses prefixed selectors
+- [ ] Visual regression tests pass for both modes
+
+### Future Considerations
+
+1. **Apply to Other Blocks** - Leadin block also has unprefixed `container-lockup`
+2. **Deprecation Timeline** - Consider deprecating legacy template in 2+ years when theme adoption is high
+3. **CSS Variables** - Consider using CSS custom properties for theme customization points
+4. **Documentation Site** - Maintain list of prefixed class names for all blocks

--- a/src/blocks/pullquote/edit.js
+++ b/src/blocks/pullquote/edit.js
@@ -13,7 +13,7 @@ import Background, {
 import getAllowedFormats from '../../global/allowed-formats';
 import themeOptions from '../../global/theme-options';
 import { getColorSlug } from '../../global/color-utils.mjs';
-import blockIcons from '../../components/block-icons';
+import ThemeColorPanel from '../../components/colorthemes-panel/index.js';
 
 // WordPress dependencies.
 import { __ } from '@wordpress/i18n';
@@ -26,10 +26,8 @@ import {
 } from '@wordpress/components';
 import {
 	InspectorControls,
-	PanelColorSettings,
 	RichText,
 	useBlockProps,
-	getColorObjectByAttributeValues,
 } from '@wordpress/block-editor';
 
 // Returns true if the current block style is "Default".
@@ -71,7 +69,7 @@ const allowedMedia = [ 'image' ];
 
 export default function Edit( props ) {
 	// Get the block properties.
-	const { attributes, setAttributes } = props;
+	const { attributes, setAttributes, name } = props;
 	const className = props?.className ?? '';
 
 	// Get the block attributes.
@@ -146,14 +144,8 @@ export default function Edit( props ) {
 		);
 	};
 
-	const themeColorObject = getColorObjectByAttributeValues(
-		themeOptions(),
-		themeColor
-	);
-	const textColorObject = getColorObjectByAttributeValues(
-		themeOptions(),
-		textColor
-	);
+	// themOptions() returns the full/global color palette added to editor settings.
+	const themeOptionsPalette = themeOptions();
 
 	// Return the block editor interface.
 	return (
@@ -168,54 +160,31 @@ export default function Edit( props ) {
 						value={ photoCredit }
 					/>
 				</PanelBody>
-				<PanelColorSettings
-					title={ __( 'Theme Color' ) }
-					initialOpen={ false }
-					colorSettings={ [
-						{
-							value: themeColorObject?.color,
-							onChange: ( value ) =>
-								setAttributes( {
-									themeColor: value
-										? getColorSlug( value, themeOptions() )
-										: undefined,
-								} ),
-							label: __( 'Theme' ),
-							disableCustomColors: true,
-							colors: themeOptions(),
-						},
-					] }
-				>
-					{ ! themeOptions() && (
-						<PanelRow>
-							<em>No Color Palette available for this site.</em>
-						</PanelRow>
-					) }
-				</PanelColorSettings>
-				<PanelColorSettings
-					title={ __( 'Text Color' ) }
-					description={ __( 'Description' ) }
-					colorSettings={ [
-						{
-							value: textColorObject?.color,
-							onChange: ( value ) =>
-								setAttributes( {
-									textColor: value
-										? getColorSlug( value, themeOptions() )
-										: undefined,
-								} ),
-							label: __( 'Text Color' ),
-							disableCustomColors: true,
-							colors: themeOptions(),
-						},
-					] }
-				>
-					{ ! themeOptions() && (
-						<PanelRow>
-							<em>No Color Palette available for this site.</em>
-						</PanelRow>
-					) }
-				</PanelColorSettings>
+				<ThemeColorPanel
+					blockname={ name }
+					value={ themeColor }
+					themepalette={ themeOptionsPalette }
+					onChange={ ( value, palette ) =>
+						setAttributes( {
+							themeColor: value
+								? getColorSlug( value, palette )
+								: undefined,
+						} )
+					}
+				/>
+				<ThemeColorPanel
+					title='Text Color Theme'
+					blockname={ name }
+					value={ textColor }
+					themepalette={ themeOptionsPalette }
+					onChange={ ( value, palette ) =>
+						setAttributes( {
+							textColor: value
+								? getColorSlug( value, palette )
+								: undefined,
+						} )
+					}
+				/>
 				{ mediaPositioningControls() }
 			</InspectorControls>
 			<BackgroundControls

--- a/src/blocks/pullquote/edit.js
+++ b/src/blocks/pullquote/edit.js
@@ -198,7 +198,7 @@ export default function Edit( props ) {
 				<div className="wp-block-bu-pullquote-inner">
 					{ isStyleDefault( className ) && (
 						<>
-							<figure>
+							<figure className="wp-block-bu-pullquote-background-media">
 								<Background
 									blockProps={ props }
 									isUploading={ isUploading }

--- a/src/blocks/pullquote/render.php
+++ b/src/blocks/pullquote/render.php
@@ -102,6 +102,12 @@ $block_wrapper_attributes = array(
 	'class' => implode( ' ', $classes ),
 );
 
+// Add ID attribute if anchor is set.
+if ( ! empty( $attributes['anchor'] ) ) {
+	$block_wrapper_attributes['id'] = esc_attr( $attributes['anchor'] );
+}
+
+
 ?>
 <div <?php echo wp_kses_data( get_block_wrapper_attributes( $block_wrapper_attributes ) ); ?>>
 	<div class="wp-block-bu-pullquote-inner">
@@ -110,7 +116,7 @@ $block_wrapper_attributes = array(
 				<?php do_action( 'bu_blocks_background', $attributes, 'large' ); ?>
 			</figure>
 		<?php endif; ?>
-		<blockquote>
+		<blockquote class="wp-block-bu-pullquote-blockquote">
 			<div class="container-lockup">
 				<div class="container-icon-outer">
 					<div class="container-icon-inner">

--- a/src/blocks/pullquote/render.php
+++ b/src/blocks/pullquote/render.php
@@ -106,8 +106,6 @@ $block_wrapper_attributes = array(
 if ( ! empty( $attributes['anchor'] ) ) {
 	$block_wrapper_attributes['id'] = esc_attr( $attributes['anchor'] );
 }
-
-
 ?>
 <div <?php echo wp_kses_data( get_block_wrapper_attributes( $block_wrapper_attributes ) ); ?>>
 	<div class="wp-block-bu-pullquote-inner">

--- a/src/blocks/pullquote/render.php
+++ b/src/blocks/pullquote/render.php
@@ -110,7 +110,7 @@ if ( ! empty( $attributes['anchor'] ) ) {
 <div <?php echo wp_kses_data( get_block_wrapper_attributes( $block_wrapper_attributes ) ); ?>>
 	<div class="wp-block-bu-pullquote-inner">
 		<?php if ( $is_style_default && $attributes['backgroundId'] ) : ?>
-			<figure>
+			<figure class="wp-block-bu-pullquote-background-media">
 				<?php do_action( 'bu_blocks_background', $attributes, 'large' ); ?>
 			</figure>
 		<?php endif; ?>


### PR DESCRIPTION
- Adds scss partial to blocks-bundled.scss which got the styles loading for me in my sandbox
- Add Anchor Attribute and BlockSupport for Anchor field. 

Refactor colors support. There are two goals here. We want to slowly move away from the custom colorThemes color palettes but can't break existing sites. In the previous blocks the path I figured out to do this is to add core color support which we can disable via theme.json easily. 

And then I added a custom Block Supports setting for out custom Color Themes feature so that we can disable the custom color support per block as well. This should give us flexibility and a safe-ish path forward to slowly replace the existing color support with the improved core color support to simplify the codebase. New projects using this plugin would use the new core color support.  

I also moved some of this logic earlier to a shared component to wrap the PanelColorSettings component to keep the code DRY across the multiple blocks doing the same thing. 



