### PR TITLE
allow line breaks in hed/dek title fields for leadin block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bug Fix: line breaks don't work in Leadin Block Hed/Dek fields. Sanitization is stripping <br> tags. 
+
 ## 0.4.3
 
 ### WordPress 5.8 Compatibility:

--- a/src/functions.php
+++ b/src/functions.php
@@ -20,6 +20,8 @@ function bu_blocks_kses_title() {
 		'em'     => array(),
 		'b'      => array(),
 		'i'      => array(),
+		'br'	 => array(),
+		'wbr'	 => array(),
 	);
 }
 


### PR DESCRIPTION
Fixes: INC20895694

Using `shift + enter` in a richtext field in the Leadin Block adds a line break but on output kses is stripping it. This PR allows for `<br>` tags to render. 

https://id-dakota.cms-devl.bu.edu/camed/news-events/articles/2026/trust-is-fundamental-md-and-phd-graduates-told-at-annual-convocation/